### PR TITLE
Fix doc and list-ascii-cows for true-color/ subdir instead of -tc suffix

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ For more on cosway, consult [its Wikipedia article](https://en.wikipedia.org/wik
 
 ## examples
 
-[A sample of each cow file in this repository is here](examples.md). Note that the ANSI cows like [bender.cow](https://github.com/paulkaefer/cowsay-files/blob/master/cows/bender.cow) will only render properly if your terminal client supports color. True color (ending in '-tc') cows will only render in terminals that support full 24-bit color.
+[A sample of each cow file in this repository is here](examples.md). Note that the ANSI cows like [bender.cow](https://github.com/paulkaefer/cowsay-files/blob/master/cows/bender.cow) will only render properly if your terminal client supports color. True color (those under the `true-color/` subdirectory) cows will only render in terminals that support full 24-bit color.
 
 ## .cowrc file
 This file allows you to configure a list of cows to randomly display when opening a new terminal session.

--- a/list-ascii-cows.sh
+++ b/list-ascii-cows.sh
@@ -1,23 +1,24 @@
 #!/bin/bash
+#
+# Lists all the cows that are defined with ASCII art, as opposed to
+# being generated from image files by the converter/ stuff.
+#
+# Only works if you run it from within the repo.
 
-for cowfile in cows/*.cow; do
+for cowfile in cows/*.cow cows/true-color/*.cow; do
   cowname=$(basename $cowfile)
   cowname="${cowname%.*}"
 
   imgname=""
   FILE=converter/src_images/${cowname}.png
-  if test -f "$FILE"; then
+  if [[ -f "$FILE" ]]; then
     imgname="$FILE"
-  else
-    if [[ $cowname =~ ^.*-tc$ ]]; then
-      shortname="${cowname%-tc*}"
-      FILE=converter/src_images/${shortname}.png
-      if test -f "$FILE"; then
-        imgname="$FILE"
-      fi
-    fi
   fi
-  if [ -z "$imgname" ]; then
+  FILE=converter/src_images/${cowname}-tc.png
+  if [[ -f "$FILE" ]]; then
+    imgname="$FILE"
+  fi
+  if [[ -z "$imgname" ]]; then
       echo "\"$cowname\""
   fi
 done


### PR DESCRIPTION
The actual cow files use a `true-color/` subdir instead of a `-tc` suffix in their names. This fixes the README and `list-ascii-cows.sh` to reflect that.

Closes #24.