### PR TITLE
Make cowsay-files an installable package?

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,36 @@
+# Makefile for Cowsay-Files
+
+PACKAGE_TARNAME = cowsay-files
+
+prefix = /usr/local
+exec_prefix = ${prefix}
+bindir = ${exec_prefix}/bin
+datarootdir = ${prefix}/share
+datadir = ${datarootdir}
+docdir = ${datarootdir}/doc/${PACKAGE_TARNAME}
+sysconfdir = ${prefix}/etc
+mandir=${datarootdir}/man
+srcdir = .
+
+SHELL = /bin/sh
+INSTALL = install
+INSTALL_PROGRAM = $(INSTALL)
+INSTALL_DATA = ${INSTALL} -m 644
+
+.PHONY: install uninstall
+
+install: cowrc.sh
+	$(INSTALL) -d $(DESTDIR)$(prefix)
+	$(INSTALL) -d $(DESTDIR)$(datadir)/$(PACKAGE_TARNAME)
+	$(INSTALL_DATA) cowrc.sh $(DESTDIR)$(datadir)/$(PACKAGE_TARNAME)
+	cp -R cows $(DESTDIR)$(datadir)/$(PACKAGE_TARNAME)
+	@# This cowpath.d stuff is for registering the collection with the new Cowsay-apj
+	@# fork of Cowsay, which supports pluggable cow collections.
+	@# See: https://github.com/cowsay-org/cowsay
+	$(INSTALL) -d $(DESTDIR)$(sysconfdir)/cowsay/cowpath.d
+	echo "$(datadir)/$(PACKAGE_TARNAME)/cows" > $(DESTDIR)$(sysconfdir)/cowsay/cowpath.d/$(PACKAGE_TARNAME).path
+
+uninstall:
+	rm -rf $(DESTDIR)$(datadir)/$(PACKAGE_TARNAME)/cowrc.sh
+	rm -rf $(DESTDIR)$(datadir)/$(PACKAGE_TARNAME)/cows
+	rm -f $(DESTDIR)$(sysconfdir)/cowsay/cowpath.d/$(PACKAGE_TARNAME).path

--- a/README.md
+++ b/README.md
@@ -11,47 +11,64 @@ For more on cowsay, consult [its Wikipedia article](https://en.wikipedia.org/wik
 
 [A sample of each cow file in this repository is here](examples.md). Note that the ANSI cows like [bender.cow](https://github.com/paulkaefer/cowsay-files/blob/master/cows/bender.cow) will only render properly if your terminal client supports color. True color (those under the `true-color/` subdirectory) cows will only render in terminals that support full 24-bit color.
 
-## .cowrc file
+## installation
+
+To install Cowsay-files, clone the repo or download the distribution tarball. Then run:
+
+```bash
+make install
+```
+
+Or to install it to a custom location:
+
+```bash
+make install prefix=/path/to/your/custom/installation/location
+```
+
+### cowrc.sh file
+
 This file allows you to configure a list of cows to randomly display when opening a new terminal session.
 - Note - this file counts on [fortune](https://formulae.brew.sh/formula/fortune) being installed to display your random fortunes.
 
 Can be made use of by adding the following line to your `.bashrc` file (or `.zshrc` if you use ZSH):
 
-```
-. ${GIT}/cowsay-files/.cowrc
+```bash
+. /usr/local/share/cowsay-files/cowrc.sh
 ```
 
-Replace ${GIT} with the path to your git directory, and you will get a random cow fortune on every new terminal session :)
+Now you will have some commands available and get a random cow fortune on every new terminal session :)
 
-## .bashrc file. 
-If you want to have random cows everytime that you login or open a shell add this to your `.bashrc`.
+### .bashrc file
+
+If you want to have random cows everytime that you login or open a shell, add this to your `.bashrc`.
 
 ```bash
-COWS=($(GIT)/cowsay-files/cows/*)
-RAND_COW=$(($RANDOM % $( ls $(GIT)/cowsay-files/cows/*.cow | wc -l )))
+COWS=(/usr/local/share/cowsay-files/cows/*)
+RAND_COW=$(($RANDOM % $( ls /usr/local/cowsay-files/cows/*.cow | wc -l )))
 cowsay -f ${COWS[$RAND_COW]} "ALL YOUR BASE ARE BELONG TO US"
 ```
-Replace ${GIT} with the path to your git directory, and you will get a random cow on every new terminal session. 
 
+### alternate installation locations
+
+If you installed Cowsay-files to an alternate location, replace `/usr/local` with the path to your custom prefix in the above instructions.
+
+If you want to run Cowsay-files directly from the cloned repo, replace `/usr/local/share` with the path to your cloned `cowsay-files` Git repo in the above instructions.
 
 ## Cowsay file converter
+
 Fancy pixel art cows can now be created with ease using [Charc0al's cowsay file converter](https://charc0al.github.io/cowsay-files/converter)
 
 Instructions:
 1. Create PNG or other uncompressed image of the size you want (recommend no larger than 50 x 50). I recommend using [GIMP](https://www.gimp.org/).
    - Note: The first (upper-left) pixel (0, 0) color is assumed to be background color and will not appear in the cowsay image.
-   - Colors will be mapped to default bash color palette, any colors in your image that are not part of the 256 color bash palette
-     will be mapped to the nearest color in the palette.
+   - Colors will be mapped to default bash color palette, any colors in your image that are not part of the 256 color bash palette will be mapped to the nearest color in the palette.
 2. Upload image in converter & press Convert!
 3. Enjoy!
 
 Tips for creating pixel art cows:  
-- For manually editing colors or creating cows, you can run the `palette` command (if you are making use of .cowrc) to get
-a display of your terminal color palette and the corresponding color codes.
-- If you are scaling down a pixel art image from a larger size, make sure to set "Interpolation" to None/Off or you will get
-color bleed between pixels
-- It is helpful to use a background color that is bright and very different from all other colors on your image
-so you can clearly see which pixels are background and which are image. I usually use hot pink or neon green.
+- For manually editing colors or creating cows, you can run the `cowsay-palette` command (if you are making use of cowrc.sh) to get a display of your terminal color palette and the corresponding color codes.
+- If you are scaling down a pixel art image from a larger size, make sure to set "Interpolation" to None/Off or you will get color bleed between pixels.
+- It is helpful to use a background color that is bright and very different from all other colors on your image so you can clearly see which pixels are background and which are image. I usually use hot pink or neon green.
 
 Try converting some of the [examples](https://charc0al.github.io/cowsay-files/converter/examples)!
 

--- a/cowrc.sh
+++ b/cowrc.sh
@@ -1,4 +1,9 @@
-#!/bin/sh
+# cowrc.sh
+#
+# Sets up cowsay-files related variables and functions.
+#
+# This file must be sourced inside your shell session with ". /path/to/cowrc.sh". It will not
+# work if you try to run it as a command.
 
 # This COWS variable configures what cowsay files will be displayed with the randomsay and randomfortune commands
 # Modify this list to contain whatever cows you want to see displayed with randomsay and new terminal sessions
@@ -282,8 +287,8 @@ ERROR_COWS=(
   "zombie-police"
 )
 
-COWSAY_FILES=$(dirname "$0")
-COWS_DIR="${COWSAY_FILES}/cows"
+COWSAY_FILES_ROOT=$(dirname "$0")
+COWS_DIR="${COWSAY_FILES_ROOT}/cows"
 COWRC=$0
 
 randomsay(){
@@ -329,7 +334,7 @@ alias cowrc="atom $COWRC"
 alias headsay='cowthink -f head.cow'
 alias randomfortune="clear && fortune | randomsay"
 
-palette(){
+cowsay-palette(){
   for fgbg in 38 48 ; do # Foreground / Background
     for color in {0..255} ; do # Colors
         # Display the color


### PR DESCRIPTION
Are you interested in making this project an installable package?

The installation would be done with just `make install` or `make install prefix=/path/to/my/prefix`.

This would support installing cowsay-files in a standard system-wide location, and support package managers like Homebrew and apt-get distributing cowsay-files. Then it could be wrapped up in a Homebrew formula or the like, so users could install it by just saying `brew install paulkaefer/cowsay-files/cowsay-files`. I think it would also make installation easier for users who don't want to mess around with cloning a git repo and maintaining updates there.

It also includes a hook for Cowsay-apj's pluggable cow collection feature, for users that want to use that version of Cowsay. Cowsay-apj is [my fork of cowsay](https://github.com/cowsay-org/cowsay) that I'm taking a stab at, since the original Cowsay project has been abandoned by its author. Cowsay-apj includes a `etc/cowsay/cowpath.d` mechanism that lets third-party cow collections register themselves, so if a user installs both Cowsay-apj and your cowsay-files package, then your cow definitions will automatically be available in `cowsay`, without requiring users to mess around with their `$COWPATH` settings.

I also renamed `.cowrc` to `cowrc.sh`: Removing the leading `.` makes it easier for users to find (and use tab-completion on), and the `.sh` suffix is a hint that users need to `source` that file in their shell session, instead of running it as a command. It's not really a standard rc style configuration file that gets read automatically by a tool, so a hidden `.cowrc` file doesn't seem to be the right place for it.